### PR TITLE
Modify crc32Table to uint

### DIFF
--- a/pkg/scte35/crc_32.go
+++ b/pkg/scte35/crc_32.go
@@ -28,7 +28,7 @@ var (
 	ErrCRC32Invalid = errors.New("CRC_32 not valid")
 
 	// crc32Table provides values for calculating an SCTE35 object's CRC32 value.
-	crc32Table = [...]int{
+	crc32Table = [...]uint{
 		0x00000000,
 		0x04C11DB7,
 		0x09823B6E,


### PR DESCRIPTION
When building with options GOARCH=386 the hex values in this table that start with a hex 9-F (negative int value) overflow the array/slice literal value.  The error message is:
"cannot use 0x9823B6E0 (untyped int constant 2552477408) as int value in array or slice literal (overflows)"
Changing the array value type to 'uint' fixes the build issue.