### PR TITLE
feat: SCTE-35 2023r1 compliance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+---
+name: release
+on: # yamllint disable-line rule:truthy
+  push:
+    tags: "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        id: release
+        with:
+          draft: false
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          append_body: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,6 @@
 ---
 run:
   tests: false
-  timeout: 5m
 
 linters-settings:
   errcheck:
@@ -16,7 +15,6 @@ linters:
     - containedctx
     - contextcheck
     - copyloopvar
-    - decorder
     - errname
     - errorlint
     - exhaustive
@@ -26,19 +24,15 @@ linters:
     - godox
     - gofmt
     - goimports
-    - goprintffuncname
     - gosec
-    - intrange
     - misspell
     - noctx
-    - nosprintfhostport
     - revive
-    - sqlclosecheck
     - stylecheck
+    - sqlclosecheck
     - testpackage
     - unparam
-    - wastedassign
-    - whitespace
+    - unused
 
 issues:
   include:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,20 @@
+---
+extends: default
+
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+  comments:
+    require-starting-space: true
+    ignore-shebangs: true
+    min-spaces-from-content: 1
+  indentation:
+    spaces: 2
+    indent-sequences: true
+  line-length: disable
+  quoted-strings:
+    quote-type: double
+    required: false
+    ignore: |
+      Taskfile.yaml

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,30 @@
+---
+version: "3"
+
+vars:
+  VERSION: "v1.5.0"
+
+tasks:
+  clean:
+    desc: "Clean build artifacts"
+    dir: "{{.ROOT_DIR}}"
+    silent: true
+    cmds:
+      - go clean -cache -testcache
+
+  test:
+    desc: "Run test suite"
+    dir: "{{.ROOT_DIR}}"
+    silent: true
+    cmds:
+      - go test -cover --race ./...
+
+  release:
+    desc: "Create a release for the current version."
+    silent: true
+    preconditions:
+      - sh: git diff --exit-code
+        msg: please commit changes before releasing
+    cmds:
+      - git diff --exit-code && git tag -a "v{{.VERSION}}" -m "Tagged v{{.VERSION}}"
+      - git push origin main --atomic --follow-tags

--- a/docs/scte_35_20230713.xsd
+++ b/docs/scte_35_20230713.xsd
@@ -1,0 +1,524 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This is the normative schema for SCTE 35. -->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.scte.org/schemas/35"
+	targetNamespace="http://www.scte.org/schemas/35" elementFormDefault="qualified"
+	version="20230713" attributeFormDefault="unqualified">
+	<xsd:complexType name="SpliceInfoSectionType">
+		<xsd:sequence>
+			<xsd:element ref="Ext" minOccurs="0"/>
+			<xsd:element name="EncryptedPacket" minOccurs="0">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element ref="Ext" minOccurs="0"/>
+					</xsd:sequence>
+					<xsd:attribute name="encryptionAlgorithm" type="xsd:unsignedByte" use="required"/>
+					<xsd:attribute name="cwIndex" type="xsd:unsignedByte" use="required"/>
+					<xsd:anyAttribute namespace="##any"/>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:choice>
+				<xsd:annotation>
+					<xsd:documentation>See Column XML Element in Table 7 - splice_command_type
+						Values. </xsd:documentation>
+				</xsd:annotation>
+				<xsd:element ref="SpliceNull"/>
+				<xsd:element ref="SpliceSchedule"/>
+				<xsd:element ref="SpliceInsert"/>
+				<xsd:element ref="TimeSignal"/>
+				<xsd:element ref="BandwidthReservation"/>
+				<xsd:element ref="PrivateCommand"/>
+			</xsd:choice>
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:element ref="AvailDescriptor"/>
+				<xsd:element ref="DTMFDescriptor"/>
+				<xsd:element ref="SegmentationDescriptor"/>
+				<xsd:element ref="TimeDescriptor"/>
+				<xsd:element ref="AudioDescriptor"/>
+				<xsd:element ref="PrivateDescriptor"/>
+			</xsd:choice>
+		</xsd:sequence>
+		<xsd:attribute name="sapType" default="3">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:unsignedShort">
+					<xsd:maxInclusive value="3"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="preRollMilliSeconds" type="xsd:unsignedInt" default="0">
+			<xsd:annotation>
+				<xsd:documentation>
+			This attribute does NOT correspond to any field in the binary SCTE 35 SpliceInfoSection</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ptsAdjustment" type="PTSType" default="0"/>
+		<xsd:attribute name="protocolVersion" type="xsd:unsignedByte" fixed="0"/>
+		<xsd:attribute name="tier">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:unsignedShort">
+					<xsd:maxExclusive value="4096"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:anyAttribute namespace="##any"/>
+	</xsd:complexType>
+	<xsd:element name="SpliceInfoSection" type="SpliceInfoSectionType"/>
+	<xsd:complexType name="BinaryType">
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:base64Binary">
+				<xsd:attribute name="signalType" default="SpliceInfoSection">
+					<xsd:annotation>
+						<xsd:documentation>When present, this value will typically specify that the
+							binary content represents a 'SpliceInfoSetion'. However, the binary
+							structure may be used to represent some other content and may do so by
+							providing a different type prefixed with 'other:'</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:token">
+							<xsd:pattern value="SpliceInfoSection|private:.+"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:element name="Binary" type="BinaryType">
+		<xsd:annotation>
+			<xsd:documentation>A binary representation of the in-band SpliceInfoSection or other
+				content as specified by the type attribute.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:group name="Signal">
+		<xsd:annotation>
+			<xsd:documentation>This group may be referenced in place of a SpliceInfoSection element
+				to allow for the option of a binary representation in XML.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice>
+			<xsd:element ref="SpliceInfoSection"/>
+			<xsd:element ref="Binary"/>
+		</xsd:choice>
+	</xsd:group>
+	<!--Common Types-->
+	<!--Extensibility element-->
+	<xsd:element name="Ext">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"
+				/>
+			</xsd:sequence>
+			<xsd:anyAttribute namespace="##any" processContents="lax"/>
+		</xsd:complexType>
+	</xsd:element>
+	<!-- PTSType Type -->
+	<xsd:simpleType name="PTSType">
+		<xsd:restriction base="xsd:unsignedLong">
+			<xsd:maxExclusive value="8589934592"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!--Splice Commands-->
+	<xsd:complexType name="SpliceCommandType">
+		<xsd:sequence>
+			<xsd:element ref="Ext" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:anyAttribute namespace="##any"/>
+	</xsd:complexType>
+	<!-- Splice Null -->
+	<xsd:complexType name="SpliceNullType">
+		<xsd:complexContent>
+			<xsd:extension base="SpliceCommandType"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="SpliceNull" type="SpliceNullType"/>
+	<!-- Splice Schedule -->
+	<xsd:complexType name="SpliceScheduleType">
+		<xsd:complexContent>
+			<xsd:extension base="SpliceCommandType">
+				<xsd:sequence>
+					<xsd:element name="Event" minOccurs="0" maxOccurs="255">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element ref="Ext" minOccurs="0"/>
+								<xsd:choice>
+									<xsd:element name="Program">
+										<xsd:complexType>
+											<xsd:sequence>
+												<xsd:element ref="Ext" minOccurs="0"/>
+											</xsd:sequence>
+											<xsd:attribute name="utcSpliceTime" type="xsd:dateTime"
+												use="required"/>
+											<xsd:anyAttribute namespace="##any"/>
+										</xsd:complexType>
+									</xsd:element>
+									<xsd:element name="Component" maxOccurs="255">
+										<xsd:complexType>
+											<xsd:sequence>
+												<xsd:element ref="Ext" minOccurs="0"/>
+											</xsd:sequence>
+											<xsd:attribute name="componentTag"
+												type="xsd:unsignedByte" use="required"/>
+											<xsd:attribute name="utcSpliceTime" type="xsd:dateTime"
+												use="required"/>
+											<xsd:anyAttribute namespace="##any"/>
+										</xsd:complexType>
+									</xsd:element>
+								</xsd:choice>
+								<xsd:element ref="BreakDuration" minOccurs="0"/>
+							</xsd:sequence>
+							<xsd:attribute name="spliceEventId" type="xsd:unsignedInt"/>
+							<xsd:attribute name="eventIdComplianceFlag" type="xsd:boolean"/>
+							<xsd:attribute name="spliceEventCancelIndicator" type="xsd:boolean"
+								default="0"/>
+							<xsd:attribute name="outOfNetworkIndicator" type="xsd:boolean"/>
+							<xsd:attribute name="uniqueProgramId" type="xsd:unsignedShort"/>
+							<xsd:attribute name="availNum" type="xsd:unsignedByte"/>
+							<xsd:attribute name="availsExpected" type="xsd:unsignedByte"/>
+							<xsd:anyAttribute namespace="##any"/>
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="SpliceSchedule" type="SpliceScheduleType"/>
+	<!-- Splice Insert -->
+	<xsd:complexType name="SpliceInsertType">
+		<xsd:complexContent>
+			<xsd:extension base="SpliceCommandType">
+				<xsd:sequence>
+					<xsd:choice>
+						<xsd:element name="Program">
+							<xsd:complexType>
+								<xsd:sequence>
+									<xsd:element ref="Ext" minOccurs="0"/>
+									<xsd:element ref="SpliceTime" minOccurs="0"/>
+								</xsd:sequence>
+								<xsd:anyAttribute namespace="##any"/>
+							</xsd:complexType>
+						</xsd:element>
+						<xsd:element name="Component" maxOccurs="255">
+							<xsd:complexType>
+								<xsd:sequence>
+									<xsd:element ref="Ext" minOccurs="0"/>
+									<xsd:element ref="SpliceTime" minOccurs="0"/>
+								</xsd:sequence>
+								<xsd:attribute name="componentTag" type="xsd:unsignedByte"
+									use="required"/>
+								<xsd:anyAttribute namespace="##any"/>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:choice>
+					<xsd:element ref="BreakDuration" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="spliceEventId" type="xsd:unsignedInt"/>
+				<xsd:attribute name="spliceEventCancelIndicator" type="xsd:boolean" default="0"/>
+				<xsd:attribute name="outOfNetworkIndicator" type="xsd:boolean"/>
+				<xsd:attribute name="spliceImmediateFlag" type="xsd:boolean"/>
+				<xsd:attribute name="eventIdComplianceFlag" type="xsd:boolean"/>
+				<xsd:attribute name="uniqueProgramId" type="xsd:unsignedShort"/>
+				<xsd:attribute name="availNum" type="xsd:unsignedByte"/>
+				<xsd:attribute name="availsExpected" type="xsd:unsignedByte"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="SpliceInsert" type="SpliceInsertType"/>
+	<!-- Time Signal -->
+	<xsd:complexType name="TimeSignalType">
+		<xsd:complexContent>
+			<xsd:extension base="SpliceCommandType">
+				<xsd:sequence>
+					<xsd:element ref="SpliceTime"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="TimeSignal" type="TimeSignalType"/>
+	<!-- Bandwidth Reservation -->
+	<xsd:complexType name="BandwidthReservationType">
+		<xsd:complexContent>
+			<xsd:extension base="SpliceCommandType"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="BandwidthReservation" type="BandwidthReservationType"/>
+	<!-- Private -->
+	<xsd:complexType name="PrivateCommandType">
+		<xsd:complexContent>
+			<xsd:extension base="SpliceCommandType">
+				<xsd:sequence>
+					<xsd:element name="PrivateBytes" type="xsd:hexBinary" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="identifier" type="xsd:unsignedInt" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="PrivateCommand" type="PrivateCommandType"/>
+	<!-- Splice Time -->
+	<xsd:complexType name="SpliceTimeType">
+		<xsd:sequence>
+			<xsd:element ref="Ext" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="ptsTime" type="PTSType"/>
+		<xsd:anyAttribute namespace="##any"/>
+	</xsd:complexType>
+	<xsd:element name="SpliceTime" type="SpliceTimeType"/>
+	<!-- Break Duration -->
+	<xsd:complexType name="BreakDurationType">
+		<xsd:sequence>
+			<xsd:element ref="Ext" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="autoReturn" type="xsd:boolean" use="required"/>
+		<xsd:attribute name="duration" type="PTSType" use="required"/>
+		<xsd:anyAttribute namespace="##any"/>
+	</xsd:complexType>
+	<xsd:element name="BreakDuration" type="BreakDurationType"/>
+	<!--Splice Descriptors -->
+	<xsd:complexType name="SpliceDescriptorType" abstract="true">
+		<xsd:sequence>
+			<xsd:element ref="Ext" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:anyAttribute namespace="##any"/>
+	</xsd:complexType>
+	<!-- Avail Descriptor -->
+	<xsd:complexType name="AvailDescriptorType">
+		<xsd:complexContent>
+			<xsd:extension base="SpliceDescriptorType">
+				<xsd:attribute name="providerAvailId" type="xsd:unsignedInt" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="AvailDescriptor" type="AvailDescriptorType"/>
+	<!-- DTMF Descriptor -->
+	<xsd:complexType name="DTMFDescriptorType">
+		<xsd:complexContent>
+			<xsd:extension base="SpliceDescriptorType">
+				<xsd:attribute name="preroll" type="xsd:unsignedByte"/>
+				<xsd:attribute name="chars">
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:token">
+							<xsd:whiteSpace value="collapse"/>
+							<xsd:pattern value="[0-9#\*]+"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="DTMFDescriptor" type="DTMFDescriptorType"/>
+	<!-- Segmentation Descriptor -->
+	<xsd:complexType name="SegmentationDescriptorType">
+		<xsd:complexContent>
+			<xsd:extension base="SpliceDescriptorType">
+				<xsd:sequence>
+					<xsd:element name="DeliveryRestrictions" minOccurs="0">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element ref="Ext" minOccurs="0"/>
+							</xsd:sequence>
+							<xsd:attribute name="webDeliveryAllowedFlag" type="xsd:boolean"
+								use="required"/>
+							<xsd:attribute name="noRegionalBlackoutFlag" type="xsd:boolean"
+								use="required"/>
+							<xsd:attribute name="archiveAllowedFlag" type="xsd:boolean"
+								use="required"/>
+							<xsd:attribute name="deviceRestrictions" use="required">
+								<xsd:annotation>
+									<xsd:documentation>See Table 21 - device_restrictions
+									</xsd:documentation>
+								</xsd:annotation>
+								<xsd:simpleType>
+									<xsd:restriction base="xsd:unsignedByte">
+										<xsd:maxInclusive value="3"/>
+									</xsd:restriction>
+								</xsd:simpleType>
+							</xsd:attribute>
+							<xsd:anyAttribute namespace="##any"/>
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element ref="SegmentationUpid" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="Component" minOccurs="0" maxOccurs="255">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element ref="Ext" minOccurs="0"/>
+							</xsd:sequence>
+							<xsd:attribute name="componentTag" type="xsd:unsignedByte"
+								use="required"/>
+							<xsd:attribute name="ptsOffset" type="PTSType" use="required"/>
+							<xsd:anyAttribute namespace="##any"/>
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="segmentationEventId" type="xsd:unsignedInt"/>
+				<xsd:attribute name="segmentationEventCancelIndicator" type="xsd:boolean"
+					default="0"/>
+				<xsd:attribute name="segmentationEventIdComplianceIndicatorbute" type="xsd:boolean"/>
+				<xsd:attribute name="segmentationDuration">
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:unsignedLong">
+							<xsd:maxExclusive value="1099511627776"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="segmentationTypeId" type="xsd:unsignedByte">
+					<xsd:annotation>
+						<xsd:documentation>See Table 23 - segmentation_type_id </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="segmentNum" type="xsd:unsignedByte"/>
+				<xsd:attribute name="segmentsExpected" type="xsd:unsignedByte"/>
+				<xsd:attribute name="subSegmentNum" type="xsd:unsignedByte"/>
+				<xsd:attribute name="subSegmentsExpected" type="xsd:unsignedByte"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="SegmentationDescriptor" type="SegmentationDescriptorType"/>
+	<!-- Segmentation Upid Type -->
+	<xsd:complexType name="SegmentationUpidType">
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:token">
+				<xsd:attribute name="segmentationUpidType" type="xsd:unsignedByte">
+				</xsd:attribute>
+				<xsd:attribute name="formatIdentifier" type="xsd:unsignedInt">
+				</xsd:attribute>
+				<xsd:attribute name="segmentationUpidFormat">
+					<xsd:annotation>
+						<xsd:documentation>The format of the Upid value. Valid values are: text, hexbinary, base-64 or private: </xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:string">
+							<xsd:pattern value="text|hexbinary|base-64|private:.+"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:anyAttribute namespace="##any"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:element name="SegmentationUpid" type="SegmentationUpidType"/>
+	<xsd:complexType name="TimeDescriptorType">
+		<xsd:complexContent>
+			<xsd:extension base="SpliceDescriptorType">
+				<xsd:attribute name="taiSeconds">
+					<xsd:annotation>
+						<xsd:documentation>Restricted to 48 bit unsigned</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:unsignedLong">
+							<xsd:maxInclusive value="281474976710656"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="taiNs" type="xsd:unsignedInt"/>
+				<xsd:attribute name="utcOffset" type="xsd:unsignedShort"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="TimeDescriptor" type="TimeDescriptorType"/>
+	<xsd:element name="AudioChannel" type="AudioChannelType"/>
+	<xsd:element name="AudioDescriptor">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="AudioDescriptorType">
+					<xsd:sequence maxOccurs="15">
+						<xsd:element ref="AudioChannel"/>
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="AudioDescriptorType">
+		<xsd:complexContent>
+			<xsd:extension base="SpliceDescriptorType"> </xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="AudioChannelType">
+		<xsd:complexContent>
+			<xsd:extension base="SpliceDescriptorType">
+				<xsd:attribute name="ISOCode" type="xsd:language" use="required"/>
+				<xsd:attribute name="BitStreamMode" use="required">
+					<xsd:annotation>
+						<xsd:documentation>bsmod	acmod 	Type of Service
+‘000’	any 	main audio service: complete main (CM)
+‘001’ 	any 	main audio service: music and effects (ME)
+‘010’ 	any 	associated service: visually impaired (VI)
+‘011’ 	any 	associated service: hearing impaired (HI)
+‘100’ 	any 	associated service: dialogue (D)
+‘101’ 	any 	associated service: commentary (C)
+‘110’ 	any 	associated service: emergency (E)
+‘111’ 	‘001’ 	associated service: voice over (VO)
+‘111’ 	‘010’-‘111’ main audio service: karaoke</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:unsignedByte">
+							<xsd:maxInclusive value="7"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="NumChannels" use="required">
+					<xsd:annotation>
+						<xsd:documentation>This is a 4-bit field that indicates the number of channels in the AC-3 elementary stream. When the MSB is 0, the lower 3 bits are set to the same value as the acmod field in the AC-3 elementary stream. When the MSB field is 1, the lower 3 bits indicate the maximum number of encoded audio channels (counting the lfe channel as 1).
+
+num_channels 	Audio coding mode (acmod)
+‘0000’ 		1 + 1
+‘0001’ 		1/0
+‘0010’ 		2/0
+‘0011’ 		3/0
+‘0100’ 		2/1
+‘0101’ 		3/1
+‘0110’ 		2/2
+‘0111’ 		3/2
+num_channels 	Number of encoded channels
+‘1000’ 		1
+‘1001’ 		≤ 2
+‘1010’ 		≤ 3
+‘1011’ 		≤ 4
+‘1100’ 		≤ 5
+‘1101’ 		≤ 6
+‘1110’ 		Reserved
+‘1111’ 		Reserved</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:unsignedByte">
+							<xsd:maxInclusive value="15"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="FullSrvcAudio" use="required">
+					<xsd:annotation>
+						<xsd:documentation>This is a 1-bit field that indicates whether or not this audio service is a full service suitable for presentation, or whether this audio service is only a partial service which should be
+combined with another audio service before presentation. This bit should be set to a ‘1’ if this audio service is sufficiently complete to be presented to the listener without being combined with another audio service (for example, a visually impaired service which contains all elements of the program; music, effects, dialogue, and the visual content descriptive narrative). This bit should be set to a ‘0’ if the service is not sufficiently complete to be presented without
+being combined with another audio service (e.g., a visually impaired service which only contains a narrative description of the visual program content and which needs to be combined with another audio service which contains music, effects, and dialogue).</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:unsignedByte">
+							<xsd:maxInclusive value="1"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="componentTag" type="xsd:unsignedByte">
+					<xsd:annotation>
+						<xsd:documentation>An optional 8-bit value that identifies the elementary PID stream containing the audio channel that follows. If used the value shall be the same as the value used in the stream_identification_descriptor() to identify that elementary PID stream. If this is not used the value shall be 0xFF and the stream order shall be inferred from the PMT audio order.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- Private Descriptor -->
+	<xsd:complexType name="PrivateDescriptorType">
+		<xsd:complexContent>
+			<xsd:extension base="SpliceDescriptorType">
+				<xsd:sequence>
+					<xsd:element name="PrivateBytes" type="xsd:hexBinary" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="descriptorTag" type="xsd:unsignedByte" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The descriptor tags are defined by the owner of the descriptor, as registered using the identifier.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="identifier" type="xsd:unsignedInt" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Only identifier values registered and recognized by SMPTE Registration Authority, LLC should be used.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="PrivateDescriptor" type="PrivateDescriptorType"/>
+</xsd:schema>

--- a/pkg/scte35/scte35.go
+++ b/pkg/scte35/scte35.go
@@ -22,7 +22,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
-	"io"
 	"log"
 	"math"
 	"strings"
@@ -54,7 +53,7 @@ var (
 )
 
 // Logger for emitting debug messages.
-var Logger = log.New(io.Discard, "SCTE35 ", log.Ldate|log.Ltime|log.Llongfile)
+var Logger = log.Default()
 
 // DecodeBase64 is a convenience function for decoding a base-64 string into
 // a SpliceInfoSection. If an error occurs, the returned SpliceInfoSection

--- a/pkg/scte35/scte35_test.go
+++ b/pkg/scte35/scte35_test.go
@@ -58,6 +58,7 @@ func TestDecodeBase64(t *testing.T) {
 				},
 				SpliceDescriptors: []scte35.SpliceDescriptor{
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							NoRegionalBlackoutFlag: true,
 							ArchiveAllowedFlag:     true,
@@ -113,6 +114,7 @@ func TestDecodeBase64(t *testing.T) {
 				},
 				SpliceDescriptors: []scte35.SpliceDescriptor{
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							NoRegionalBlackoutFlag: true,
 							ArchiveAllowedFlag:     true,
@@ -142,6 +144,7 @@ func TestDecodeBase64(t *testing.T) {
 				},
 				SpliceDescriptors: []scte35.SpliceDescriptor{
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							NoRegionalBlackoutFlag: true,
 							ArchiveAllowedFlag:     true,
@@ -155,6 +158,7 @@ func TestDecodeBase64(t *testing.T) {
 						},
 					},
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							NoRegionalBlackoutFlag: true,
 							ArchiveAllowedFlag:     true,
@@ -183,6 +187,7 @@ func TestDecodeBase64(t *testing.T) {
 				},
 				SpliceDescriptors: []scte35.SpliceDescriptor{
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							NoRegionalBlackoutFlag: true,
 							ArchiveAllowedFlag:     true,
@@ -211,6 +216,7 @@ func TestDecodeBase64(t *testing.T) {
 				},
 				SpliceDescriptors: []scte35.SpliceDescriptor{
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							NoRegionalBlackoutFlag: true,
 							ArchiveAllowedFlag:     true,
@@ -224,6 +230,7 @@ func TestDecodeBase64(t *testing.T) {
 						},
 					},
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							NoRegionalBlackoutFlag: true,
 							ArchiveAllowedFlag:     true,
@@ -252,6 +259,7 @@ func TestDecodeBase64(t *testing.T) {
 				},
 				SpliceDescriptors: []scte35.SpliceDescriptor{
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							NoRegionalBlackoutFlag: true,
 							ArchiveAllowedFlag:     true,
@@ -280,6 +288,7 @@ func TestDecodeBase64(t *testing.T) {
 				},
 				SpliceDescriptors: []scte35.SpliceDescriptor{
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							NoRegionalBlackoutFlag: true,
 							ArchiveAllowedFlag:     true,
@@ -294,6 +303,7 @@ func TestDecodeBase64(t *testing.T) {
 						SegmentNum: 2,
 					},
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							NoRegionalBlackoutFlag: true,
 							ArchiveAllowedFlag:     true,
@@ -307,6 +317,7 @@ func TestDecodeBase64(t *testing.T) {
 						},
 					},
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							NoRegionalBlackoutFlag: true,
 							ArchiveAllowedFlag:     true,
@@ -354,6 +365,7 @@ func TestDecodeBase64(t *testing.T) {
 				SpliceCommand: scte35.NewTimeSignal(7316880262),
 				SpliceDescriptors: []scte35.SpliceDescriptor{
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							ArchiveAllowedFlag:     true,
 							WebDeliveryAllowedFlag: true,
@@ -371,6 +383,7 @@ func TestDecodeBase64(t *testing.T) {
 						SegmentationEventID: 1073742098,
 					},
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							ArchiveAllowedFlag:     true,
 							WebDeliveryAllowedFlag: true,
@@ -423,6 +436,7 @@ func TestDecodeBase64(t *testing.T) {
 				SpliceCommand: scte35.NewTimeSignal(4294967296),
 				SpliceDescriptors: []scte35.SpliceDescriptor{
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						SegmentationUPIDs: []scte35.SegmentationUPID{
 							{
 								Type:   scte35.SegmentationUPIDTypeEIDR,
@@ -456,6 +470,7 @@ func TestDecodeBase64(t *testing.T) {
 				SpliceCommand: scte35.NewTimeSignal(3550479013),
 				SpliceDescriptors: []scte35.SpliceDescriptor{
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						SegmentationUPIDs: []scte35.SegmentationUPID{
 							{
 								Type:             scte35.SegmentationUPIDTypeMPU,
@@ -497,11 +512,12 @@ func TestDecodeBase64(t *testing.T) {
 								Value:  "urn:nbcuni.com:brc:499866434",
 							},
 						},
-						SegmentationDuration: ptr(uint64(1347087)),
-						SegmentationEventID:  4294967295,
-						SegmentationTypeID:   scte35.SegmentationTypeProviderAdEnd,
-						SegmentNum:           10,
-						SegmentsExpected:     1,
+						SegmentationDuration:                   ptr(uint64(1347087)),
+						SegmentationEventID:                    4294967295,
+						SegmentationEventIDComplianceIndicator: true,
+						SegmentationTypeID:                     scte35.SegmentationTypeProviderAdEnd,
+						SegmentNum:                             10,
+						SegmentsExpected:                       1,
 					},
 				},
 				Tier:    4095,
@@ -546,22 +562,24 @@ func TestDecodeBase64(t *testing.T) {
 				},
 				SpliceDescriptors: scte35.SpliceDescriptors{
 					&scte35.SegmentationDescriptor{
-						SegmentationEventID: uint32(156),
-						SegmentationTypeID:  scte35.SegmentationTypeProviderAdEnd,
-						SegmentNum:          7,
-						SegmentsExpected:    10,
+						SegmentationEventID:                    uint32(156),
+						SegmentationTypeID:                     scte35.SegmentationTypeProviderAdEnd,
+						SegmentNum:                             7,
+						SegmentsExpected:                       10,
+						SegmentationEventIDComplianceIndicator: true,
 						SegmentationUPIDs: []scte35.SegmentationUPID{
 							{Type: scte35.SegmentationUPIDTypeADS, Format: scte35.SegmentationUPIDFormatText, Value: "availid=914866065\u0026bitmap=\u0026inactivity=3120"},
 						},
 					},
 					&scte35.SegmentationDescriptor{
-						SegmentationEventID:  uint32(157),
-						SegmentationTypeID:   scte35.SegmentationTypeProviderAdStart,
-						SegmentationDuration: ptr(uint64(3600000)),
-						SegmentNum:           8,
-						SegmentsExpected:     10,
-						SubSegmentNum:        ptr(uint32(0)),
-						SubSegmentsExpected:  ptr(uint32(0)),
+						SegmentationEventID:                    uint32(157),
+						SegmentationTypeID:                     scte35.SegmentationTypeProviderAdStart,
+						SegmentationEventIDComplianceIndicator: true,
+						SegmentationDuration:                   ptr(uint64(3600000)),
+						SegmentNum:                             8,
+						SegmentsExpected:                       10,
+						SubSegmentNum:                          ptr(uint32(0)),
+						SubSegmentsExpected:                    ptr(uint32(0)),
 						SegmentationUPIDs: []scte35.SegmentationUPID{
 							{Type: scte35.SegmentationUPIDTypeADS, Format: scte35.SegmentationUPIDFormatText, Value: "availid=910901389\u0026bitmap=\u0026inactivity=3120"},
 						},
@@ -579,8 +597,9 @@ func TestDecodeBase64(t *testing.T) {
 				},
 				SpliceDescriptors: scte35.SpliceDescriptors{
 					&scte35.SegmentationDescriptor{
-						SegmentationEventID: uint32(1074667968),
-						SegmentationTypeID:  scte35.SegmentationTypeBreakEnd,
+						SegmentationEventID:                    uint32(1074667968),
+						SegmentationTypeID:                     scte35.SegmentationTypeBreakEnd,
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							ArchiveAllowedFlag:     true,
 							WebDeliveryAllowedFlag: true,
@@ -592,8 +611,9 @@ func TestDecodeBase64(t *testing.T) {
 						},
 					},
 					&scte35.SegmentationDescriptor{
-						SegmentationEventID: uint32(1074668380),
-						SegmentationTypeID:  scte35.SegmentationTypeProgramEnd,
+						SegmentationEventID:                    uint32(1074668380),
+						SegmentationTypeID:                     scte35.SegmentationTypeProgramEnd,
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							ArchiveAllowedFlag:     true,
 							WebDeliveryAllowedFlag: true,
@@ -605,8 +625,9 @@ func TestDecodeBase64(t *testing.T) {
 						},
 					},
 					&scte35.SegmentationDescriptor{
-						SegmentationEventID: uint32(1074668000),
-						SegmentationTypeID:  scte35.SegmentationTypeProgramStart,
+						SegmentationEventID:                    uint32(1074668000),
+						SegmentationTypeID:                     scte35.SegmentationTypeProgramStart,
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							ArchiveAllowedFlag:     true,
 							WebDeliveryAllowedFlag: true,
@@ -618,9 +639,10 @@ func TestDecodeBase64(t *testing.T) {
 						},
 					},
 					&scte35.SegmentationDescriptor{
-						SegmentationEventID:  uint32(1074667978),
-						SegmentationDuration: ptr(uint64(5412012)),
-						SegmentationTypeID:   scte35.SegmentationTypeBreakStart,
+						SegmentationEventID:                    uint32(1074667978),
+						SegmentationEventIDComplianceIndicator: true,
+						SegmentationDuration:                   ptr(uint64(5412012)),
+						SegmentationTypeID:                     scte35.SegmentationTypeBreakStart,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							ArchiveAllowedFlag:     true,
 							WebDeliveryAllowedFlag: true,
@@ -632,11 +654,12 @@ func TestDecodeBase64(t *testing.T) {
 						},
 					},
 					&scte35.SegmentationDescriptor{
-						SegmentationEventID:  uint32(1074667990),
-						SegmentationTypeID:   0x05,
-						SegmentationDuration: ptr(uint64(5412012)),
-						SegmentNum:           6,
-						SegmentsExpected:     255,
+						SegmentationEventID:                    uint32(1074667990),
+						SegmentationEventIDComplianceIndicator: true,
+						SegmentationTypeID:                     0x05,
+						SegmentationDuration:                   ptr(uint64(5412012)),
+						SegmentNum:                             6,
+						SegmentsExpected:                       255,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							ArchiveAllowedFlag:     true,
 							WebDeliveryAllowedFlag: false,
@@ -718,6 +741,7 @@ func TestDecodeHex(t *testing.T) {
 				},
 				SpliceDescriptors: []scte35.SpliceDescriptor{
 					&scte35.SegmentationDescriptor{
+						SegmentationEventIDComplianceIndicator: true,
 						DeliveryRestrictions: &scte35.DeliveryRestrictions{
 							NoRegionalBlackoutFlag: true,
 							ArchiveAllowedFlag:     true,

--- a/pkg/scte35/segmentation_upid.go
+++ b/pkg/scte35/segmentation_upid.go
@@ -34,15 +34,18 @@ const (
 	SegmentationUPIDTypeNotUsed = 0x00
 	// SegmentationUPIDTypeUserDefined is the segmentation_upid_type for User
 	// Defined.
+	// Deprecated.
 	SegmentationUPIDTypeUserDefined = 0x01
 	// SegmentationUPIDTypeISCI is the segmentation_upid_type for ISCI
+	// Deprecated.
 	SegmentationUPIDTypeISCI = 0x02
 	// SegmentationUPIDTypeAdID is the segmentation_upid_type for Ad-ID
 	SegmentationUPIDTypeAdID = 0x03
 	// SegmentationUPIDTypeUMID is the segmentation_upid_type for UMID
 	SegmentationUPIDTypeUMID = 0x04
 	// SegmentationUPIDTypeISANDeprecated is the segmentation_upid_type for
-	// ISAN Deprecated.
+	// ISAN.
+	// Deprecated.
 	SegmentationUPIDTypeISANDeprecated = 0x05
 	// SegmentationUPIDTypeISAN is the segmentation_upid_type for ISAN.
 	SegmentationUPIDTypeISAN = 0x06

--- a/pkg/scte35/splice_insert.go
+++ b/pkg/scte35/splice_insert.go
@@ -32,9 +32,10 @@ const (
 // SpliceInsert is a  command shall be sent at least once for every splice
 // event.
 type SpliceInsert struct {
-	XMLName                    xml.Name                `xml:"http://www.scte.org/schemas/35 SpliceInsert" json:"-"`
-	JSONType                   uint32                  `xml:"-" json:"type"`
-	Program                    *SpliceInsertProgram    `xml:"http://www.scte.org/schemas/35 Program" json:"program,omitempty"`
+	XMLName  xml.Name             `xml:"http://www.scte.org/schemas/35 SpliceInsert" json:"-"`
+	JSONType uint32               `xml:"-" json:"type"`
+	Program  *SpliceInsertProgram `xml:"http://www.scte.org/schemas/35 Program" json:"program,omitempty"`
+	// Deprecated.
 	Components                 []SpliceInsertComponent `xml:"http://www.scte.org/schemas/35 Component" json:"components,omitempty"`
 	BreakDuration              *BreakDuration          `xml:"http://www.scte.org/schemas/35 BreakDuration" json:"breakDuration,omitempty"`
 	SpliceEventID              uint32                  `xml:"spliceEventId,attr" json:"spliceEventId,omitempty"`
@@ -292,6 +293,7 @@ func (cmd SpliceInsert) length() int {
 }
 
 // SpliceInsertComponent contains the Splice Point in Component Splice Mode.
+// Deprecated.
 type SpliceInsertComponent struct {
 	Tag        uint32      `xml:"componentTag,attr" json:"componentTag,omitempty"`
 	SpliceTime *SpliceTime `xml:"http://www.scte.org/schemas/35 SpliceTime" json:"spliceTime,omitempty"`


### PR DESCRIPTION
Update library to be compliant with SCTE-35 2023r1

* Update `segmentation_type_ids` that allow `sub_segment_num` and `sub_segments_expected` to include `0x30`, `0x32`, `0x34`, `0x36`, `0x38`, `0x3a`, `0x44`, and `0x46`

* Add `segmentation_event_id_compliance_indicator` to `segmentation_descriptor()`.

* Add `event_id_compliance_flag` to `splice_schedule()`.

* Deprecate attributes, structs, and constants related to Component Splice Mode.
