### PR TITLE
fix duration handling and conversion

### DIFF
--- a/pkg/scte35/scte35.go
+++ b/pkg/scte35/scte35.go
@@ -35,6 +35,8 @@ const (
 	Reserved = 0xFF
 	// TicksPerSecond is the number of 90KHz ticks per second
 	TicksPerSecond = 90000
+	// TicksPerNanosecond is the number of 90KHz ticks per nanosecond
+	TicksPerNanosecond = 0.00009
 	// unixEpochToGPSEpoch is the number of seconds between 1970-01-01T00:00:00Z
 	// (Unix Epoch) and 1980-01-06T00:00:00Z (GPS Epoch).
 	unixEpochToGPSEpoch = uint32(315964800)
@@ -83,15 +85,14 @@ func DecodeHex(s string) (*SpliceInfoSection, error) {
 	return sis, err
 }
 
-// DurationToTicks converts a duration to 90MhZ ticks.
+// DurationToTicks converts a duration to 90kHz ticks.
 func DurationToTicks(d time.Duration) uint64 {
-	return uint64(math.Ceil(float64(d) * TicksPerSecond / float64(time.Second)))
+	return uint64(math.Round(float64(d.Nanoseconds()) * TicksPerNanosecond))
 }
 
-// TicksToDuration converts 90MhZ ticks to a duration.
+// TicksToDuration converts 90kHz ticks to a duration.
 func TicksToDuration(ticks uint64) time.Duration {
-	s := float64(ticks) / float64(TicksPerSecond)
-	return time.Duration(int64(s * float64(time.Second)))
+	return time.Duration(math.Round((float64(ticks) / TicksPerNanosecond)))
 }
 
 // BreakDuration specifies the duration of the commercial break(s). It may be

--- a/pkg/scte35/splice_info_section.go
+++ b/pkg/scte35/splice_info_section.go
@@ -153,15 +153,15 @@ func (sis *SpliceInfoSection) Duration() time.Duration {
 		}
 	}
 
-	ticks := uint64(0)
+	// otherwise return the first segmentation duration found
 	for _, sd := range sis.SpliceDescriptors {
 		if sdt, ok := sd.(*SegmentationDescriptor); ok {
 			if sdt.SegmentationDuration != nil {
-				ticks += *sdt.SegmentationDuration
+				return TicksToDuration(*sdt.SegmentationDuration)
 			}
 		}
 	}
-	return TicksToDuration(ticks)
+	return time.Duration(0)
 }
 
 // Encode returns the binary representation of this SpliceInfoSection as a

--- a/pkg/scte35/splice_info_section.go
+++ b/pkg/scte35/splice_info_section.go
@@ -144,12 +144,12 @@ func (sis *SpliceInfoSection) Decode(b []byte) (err error) {
 	return nil
 }
 
-// Duration attempts to return the duration of the signal.
-func (sis *SpliceInfoSection) Duration() time.Duration {
+// DurationTicks attempts to return the duration of the signal in ticks.
+func (sis *SpliceInfoSection) DurationTicks() uint64 {
 	// if this is a splice insert with a duration, use it
 	if sc, ok := sis.SpliceCommand.(*SpliceInsert); ok {
 		if sc.BreakDuration != nil {
-			return TicksToDuration(sc.BreakDuration.Duration)
+			return sc.BreakDuration.Duration
 		}
 	}
 
@@ -157,11 +157,16 @@ func (sis *SpliceInfoSection) Duration() time.Duration {
 	for _, sd := range sis.SpliceDescriptors {
 		if sdt, ok := sd.(*SegmentationDescriptor); ok {
 			if sdt.SegmentationDuration != nil {
-				return TicksToDuration(*sdt.SegmentationDuration)
+				return *sdt.SegmentationDuration
 			}
 		}
 	}
-	return time.Duration(0)
+	return 0
+}
+
+// Duration attempts to return the duration of the signal.
+func (sis *SpliceInfoSection) Duration() time.Duration {
+	return TicksToDuration(sis.DurationTicks())
 }
 
 // Encode returns the binary representation of this SpliceInfoSection as a


### PR DESCRIPTION
This PR fixes two issues and adds a feature. It consists of three commits for more clarity:

Commit 1:  For time signals the current code loops through all segmentation descriptors and adds up all duration values. This is completely incorrect. While there might be multiple segmentation described, they all start at the same time and run in parallel, so the duration values do not add up. There is no single correct solution. My change just returns the first actual duration found instead. Other possible choices would be to either return the smallest or the biggest value. But users dealing with signals with conflicting values should probably not use this method in the first place.

Commit 2: The helper functions DurationToTicks and TicksToDuration introduce rounding errors. For example for a duration value 12322800 the duration should be exactly 136920 milliseconds (as the value can be cleanly divided by 90). But the current code results in a value of 13691.999999 milliseconds instead. This happens due to calculating the duration as seconds first and then converting it back to a time.Duration value which has nanosecond base. The changed code introduces a new const TicksPerNanosecond and calculates directly on the nanosecond base, reducing the number of operations which can introduce inaccuracies. Also use math.Round() instead of math.Ceil() at DurationToTicks because that seems more sensible. The existing test for TicksToDurations has been extended to catch the rounding error described before. Also a new test has been added to test for the other way around, testing durations which represent full frames for usual framerates.

Commit 3: Add a new method DurationTicks() to allow the use to get the raw value instead of a time.Duration which can be helpful for debugging broken markers. 