### PR TITLE
Fix unnecessary early overflow in NewUTCSpliceTime, add tests

### DIFF
--- a/pkg/scte35/scte35.go
+++ b/pkg/scte35/scte35.go
@@ -39,7 +39,7 @@ const (
 	TicksPerNanosecond = 0.00009
 	// unixEpochToGPSEpoch is the number of seconds between 1970-01-01T00:00:00Z
 	// (Unix Epoch) and 1980-01-06T00:00:00Z (GPS Epoch).
-	unixEpochToGPSEpoch = uint32(315964800)
+	unixEpochToGPSEpoch = 315964800
 )
 
 var (
@@ -123,10 +123,10 @@ func (bb *Bytes) UnmarshalText(b []byte) error {
 }
 
 // NewUTCSpliceTime creates a UTCSpliceTime representing the number of seconds
-// from GPS Epoch (01 Jan 1980, 00:00:00 UTC)
+// from GPS Epoch (06 Jan 1980, 00:00:00 UTC)
 func NewUTCSpliceTime(sec uint32) UTCSpliceTime {
 	return UTCSpliceTime{
-		time.Unix(int64(sec+unixEpochToGPSEpoch), 0),
+		time.Unix(int64(sec)+unixEpochToGPSEpoch, 0).UTC(),
 	}
 }
 
@@ -137,7 +137,7 @@ type UTCSpliceTime struct {
 
 // GPSSeconds returns the seconds since GPS Epoch
 func (t UTCSpliceTime) GPSSeconds() uint32 {
-	return uint32(t.Time.Unix()) - unixEpochToGPSEpoch
+	return uint32(t.Time.Unix() - unixEpochToGPSEpoch)
 }
 
 // readerError returns the readers error state, if any.

--- a/pkg/scte35/scte35_test.go
+++ b/pkg/scte35/scte35_test.go
@@ -849,6 +849,57 @@ func TestDurationToTicks(t *testing.T) {
 	}
 }
 
+var commonGPSTimeTestCases = map[string]struct {
+	gpsSeconds    uint32
+	utcSpliceTime scte35.UTCSpliceTime
+}{
+	"GPS Second 0": {
+		gpsSeconds: 0,
+		utcSpliceTime: scte35.UTCSpliceTime{
+			Time: time.Date(1980, time.January, 6, 0, 0, 0, 0, time.UTC),
+		},
+	},
+	// last value before a uint32 based calculation would overflow
+	"GPS Second 3979002495": {
+		gpsSeconds: 3979002495,
+		utcSpliceTime: scte35.UTCSpliceTime{
+			Time: time.Date(2106, time.February, 7, 6, 28, 15, 0, time.UTC),
+		},
+	},
+	// in a uint32 based calculation this would overflow
+	"GPS Second 3979002496": {
+		gpsSeconds: 3979002496,
+		utcSpliceTime: scte35.UTCSpliceTime{
+			Time: time.Date(2106, time.February, 7, 6, 28, 16, 0, time.UTC),
+		},
+	},
+	// highest possible value
+	"GPS Second 4294967295": {
+		gpsSeconds: 4294967295,
+		utcSpliceTime: scte35.UTCSpliceTime{
+			Time: time.Date(2116, time.February, 12, 6, 28, 15, 0, time.UTC),
+		},
+	},
+}
+
+func TestNewUTCSpliceTime(t *testing.T) {
+	for k, c := range commonGPSTimeTestCases {
+		t.Run(k, func(t *testing.T) {
+			utcSpliceTime := scte35.NewUTCSpliceTime(c.gpsSeconds)
+			assert.Equal(t, c.utcSpliceTime.Time, utcSpliceTime.Time)
+		})
+	}
+}
+
+func TestUTCSpliceTimeGPSSeconds(t *testing.T) {
+	for k, c := range commonGPSTimeTestCases {
+		t.Run(k, func(t *testing.T) {
+			gpsSeconds := c.utcSpliceTime.GPSSeconds()
+			assert.Equal(t, c.gpsSeconds, gpsSeconds)
+		})
+	}
+}
+
 // helper func to make test life a bit easier
 
 func toBytes(i uint64) []byte {


### PR DESCRIPTION
While looking through the code for functions/methods that maybe should have a test, I noticed that `NewUTCSpliceTime` overflows when the gpsepoch input plus the offset between unix epoch and gps epoch exceeds uint32. While this only happens in the year 2106 and it is questionable (but not ruled out :grimacing: ) that SCTE35 is still in use then, I found it wrong to leave it like that. Fixed that, now it works with all values for gpsepoch, which only overflows in the year 2116 when the range really ends (so roughly 10 years later). Also internally the time was not stored as UTC. While that probably makes no difference, I fixed that too.

The GPSSeconds method of UTCSpliceTime likewise had a overflow in the year 2106. Here it did not affect the result, as the subsequent subtraction in uint32 number space still resulted in the correct result, but again it felt wrong, to leave it like that.

Also added tests.